### PR TITLE
Fix cloning issues (hair + HAR compatibility)

### DIFF
--- a/QEE/CompatibilityTracker.cs
+++ b/QEE/CompatibilityTracker.cs
@@ -57,7 +57,7 @@ namespace QEthics
                 }
 
                 //Enhanced compatibility mods
-                else if (modName.Contains("Humanoid Alien Races 2.0"))
+                else if (modName.Contains("Humanoid Alien Races"))
                 {
                     alienRacesActiveInt = true;
                     QEEMod.TryLog("Humanoid Alien Races detected");

--- a/QEE/Things/Building_PawnVatGrower.cs
+++ b/QEE/Things/Building_PawnVatGrower.cs
@@ -397,7 +397,6 @@ namespace QEthics
 
         public override void DrawAt(Vector3 drawLoc, bool flip = false)
         {
-            Log.Message("TEST");
             //Draw bottom graphic
             Vector3 drawAltitude = drawLoc;
             if (VatGrowerProps.bottomGraphic != null)

--- a/QEE/Utilities/GenomeUtility.cs
+++ b/QEE/Utilities/GenomeUtility.cs
@@ -127,7 +127,7 @@ namespace QEthics
                 }
 
                 storyTracker.hairColor = genomeSequence.hairColor;
-                //storyTracker.hairDef = genomeSequence.hair ?? PawnHairChooser.RandomHairDefFor(pawn, pawn.Faction.def);
+                storyTracker.hairDef = genomeSequence.hair ?? storyTracker.hairDef;
                 storyTracker.melanin = genomeSequence.skinMelanin;
 
                 //headGraphicPath is private, so we need Harmony to set its value


### PR DESCRIPTION
Reactivates the hair being set during the cloning process and fixes the compatibility checker looking for an outdated Humanoid Alien Race framework modname, which caused compatibility functions not to be executed during cloning.

In addition, a small test log message in the draw method of clone vats was removed.